### PR TITLE
Ignore build output and Cmake configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Created by https://www.toptal.com/developers/gitignore/api/cmake
+# Edit at https://www.toptal.com/developers/gitignore?templates=cmake
+
+
+### Build output ###
+build/
+
+### CMake ###
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+
+### CMake Patch ###
+# External projects
+*-prefix/
+
+# End of https://www.toptal.com/developers/gitignore/api/cmake


### PR DESCRIPTION
It is always good start to include the `.gitignore` file to prevent commits of temporary files, build outputs or user configurations files.

The https://gitignore.io is a service which generate common ignore settings based on favorite tools, frameworks and languages used in the project.