### PR TITLE
Link the main app code with the public interface from the `average_lib` library

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: sudo apt-get install -y g++ cmake libgtest-dev
     - name: Create Build Directory

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Created by https://www.toptal.com/developers/gitignore/api/cmake
+# Edit at https://www.toptal.com/developers/gitignore?templates=cmake
+
+
+### Build output ###
+build/
+
+### CMake ###
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+
+### CMake Patch ###
+# External projects
+*-prefix/
+
+# End of https://www.toptal.com/developers/gitignore/api/cmake

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_executable(main_app main.cpp)
-target_link_libraries(main_app PRIVATE average_lib)
+target_link_libraries(main_app PUBLIC average_lib)
+target_include_directories(main_app PUBLIC "${PROJECT_SOURCE_DIR}")

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -2,7 +2,7 @@
 #include <fstream>
 #include <vector>
 #include <string>
-#include "average.h"
+#include <lib/average.h>
 
 int main(int argc, char** argv) {
     std::string filename = "numbers.txt";

--- a/test/test_average.cpp
+++ b/test/test_average.cpp
@@ -1,4 +1,4 @@
-#include "average.h"
+#include "../lib/average.h"
 #include <gtest/gtest.h>
 #include <vector>
 


### PR DESCRIPTION
As a good practice in the C++ projects it is better to include files from other libraries using the `#include <libname/headername.h>` syntax.

Including the `average.h` in the `main.cpp` file will make it clear the header is from the library if we use this syntax:

```cpp
#include <lib/average.h>
```

To do this, we must define the includes directory in the Cmake project. Include directories are places where the compiler looks for header files included using the `<>` syntax:


```
target_include_directories(main_app PUBLIC "${PROJECT_SOURCE_DIR}")
```

This enables correct resolution for the `<lib/average.h>` file.

Alternatively, we can include the file using relative path syntax `#include "../../some/path/to/header.h"`. This would be OK for this small project. See sample of this in the `test_average.cpp` file. Such includes are resolved relatively to the `.cpp` file, but this can get messy very soon as the project grows and includes more files.