### PR TITLE
Include Google Test library directly in the project

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install dependencies
-      run: sudo apt-get install -y g++ cmake libgtest-dev
+      run: sudo apt-get install -y g++ cmake
     - name: Create Build Directory
       run: mkdir build && cd build
     - name: CMake
@@ -19,5 +19,5 @@ jobs:
       run: cmake --build .
       working-directory: ./build
     - name: Test
-      run: ctest
-      working-directory: ./build
+      run: ./test_average
+      working-directory: ./build/test

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install dependencies
       run: sudo apt-get install -y g++ cmake libgtest-dev
     - name: Create Build Directory

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Created by https://www.toptal.com/developers/gitignore/api/cmake
+# Edit at https://www.toptal.com/developers/gitignore?templates=cmake
+
+
+### Build output ###
+build/
+
+### CMake ###
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+
+### CMake Patch ###
+# External projects
+*-prefix/
+
+# End of https://www.toptal.com/developers/gitignore/api/cmake

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_executable(main_app main.cpp)
-target_link_libraries(main_app PRIVATE average_lib)
+target_link_libraries(main_app PUBLIC average_lib)
+target_include_directories(main_app PUBLIC "${PROJECT_SOURCE_DIR}")

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -2,7 +2,7 @@
 #include <fstream>
 #include <vector>
 #include <string>
-#include "average.h"
+#include <lib/average.h>
 
 int main(int argc, char** argv) {
     std::string filename = "numbers.txt";

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,17 @@
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
 enable_testing()
-find_package(GTest REQUIRED)
+
 add_executable(test_average test_average.cpp)
-target_link_libraries(test_average GTest::GTest GTest::Main average_lib)
-add_test(NAME test_average COMMAND test_average)
+target_link_libraries(test_average GTest::gtest_main average_lib)
+target_include_directories(test_average PUBLIC "${PROJECT_SOURCE_DIR}")
+
+include(GoogleTest)
+gtest_discover_tests(test_average)

--- a/test/test_average.cpp
+++ b/test/test_average.cpp
@@ -1,4 +1,4 @@
-#include "average.h"
+#include "../lib/average.h"
 #include <gtest/gtest.h>
 #include <vector>
 

--- a/test/test_average.cpp
+++ b/test/test_average.cpp
@@ -1,4 +1,4 @@
-#include "../lib/average.h"
+#include <lib/average.h>
 #include <gtest/gtest.h>
 #include <vector>
 


### PR DESCRIPTION
The last change is to improve the usage of Google Test library.

The build does not depend now on a single global version of the GTest library. If the project was written on a machine with different version of the GTest library, some functions may not be available on the build machines and the build would fail.


Referencing an exact version of a GTest library directly from the test project will make the build repeatable (eg. on different build machines, or when you need to use old version of the code to troubleshoot something).

The code is from https://google.github.io/googletest/quickstart-cmake.html
